### PR TITLE
Fixing credential leakage of RD_CONFIG_PASS in debug output

### DIFF
--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -67,7 +67,7 @@ if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
 
   puts 'ENV:'
   ENV.each do |k, v|
-    puts "#{k} => #{v}" if v != pass
+    puts "#{k} => #{v}" if v != pass && k != 'RD_CONFIG_PASS'
     puts "#{k} => ********" if v == pass || k == 'RD_CONFIG_PASS'
     # puts "#{k} => #{v}" if v == pass # uncomment it for full auth debugging
   end


### PR DESCRIPTION
Currently, when debug output is enabled, and RD_CONFIG_PASS is overridden by RD_OPTION_WINRMPASS, the value of RD_CONFIG_PASS is logged to STDOUT twice, once showing the actual value (what we don't want), and a second time showing asterisks (what we do want).

This PR fixes that bug.
