### PR TITLE
Changed shell executions to use non-deprecated methods

### DIFF
--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -101,9 +101,9 @@ winrm.set_timeout(ENV['RD_CONFIG_WINRMTIMEOUT'].to_i) if ENV['RD_CONFIG_WINRMTIM
 
 case shell
 when 'powershell'
-  result = winrm.powershell(command)
+  result = winrm.create_executor().run_powershell_script(command)
 when 'cmd'
-  result = winrm.cmd(command)
+  result = winrm.create_executor().run_cmd(command)
 when 'wql'
   result = winrm.wql(command)
 end


### PR DESCRIPTION
Currently, both the PowerShell and CMD shell executions are using deprecated APIs
to do so. As a result, each time you use this plugin, a warning is logged that
you are using a deprecated API. I have changed the plugin to use the new,
non-deprecated APIs for both PowerShell and CMD execution that were introduced
in WinRb WinRM 1.5.0. To clarify, the change that I have made is still functionally equivalent to what was being done before, but will no longer result in a warning being logged due to use of a deprecated API.
