### PR TITLE
Updated gems, Added No SSL, Add Error handling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ https://github.com/WinRb/WinRM/issues/194
 HTTPS can be selected without using 'ssl' authentication type.
 - Allow empty defaut user and password at the project level, or
 above, so only "overriding" in job options can be use instead
-- Mention in README the installation of Gem rubyntlm so NTLM
-authentification can be used, via authentication type 'negotiate'.
 
 ### [1.6.0](https://github.com/NetDocuments/rd-winrm-plugin/releases/tag/1.6.0)
 Enables basic auth (GH-34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### [1.6.0.1](https://github.com/stoned/rd-winrm-plugin/releases/tag/1.6.0.1)
+### [1.6.2](https://github.com/NetDocuments/rd-winrm-plugin/releases/tag/1.6.0.2)
 - Use Gem winrm 2.x which permit non-administrator session, see
 https://github.com/WinRb/WinRM/issues/194
 - Use Gem winrm-fs 1.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## Changelog
+### [1.7.0](https://github.com/NetDocuments/rd-winrm-plugin/releases/tag/1.7.0)
+- Update winrm and winrm-rf gems
+- Rewrite of connection portion of script to support new features of these gems
+- Add basic error handling to improve user friendliness of output
+- Removed non functioning quote bug fix, Rundeck's documentation is an adequate fix until bug is resolved internally
+- Added grouping to UI elements of plugin
 
 ### [1.6.2](https://github.com/NetDocuments/rd-winrm-plugin/releases/tag/1.6.2)
 - Use Gem winrm 2.x which permit non-administrator session, see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### [1.6.2](https://github.com/NetDocuments/rd-winrm-plugin/releases/tag/1.6.0.2)
+### [1.6.2](https://github.com/NetDocuments/rd-winrm-plugin/releases/tag/1.6.2)
 - Use Gem winrm 2.x which permit non-administrator session, see
 https://github.com/WinRb/WinRM/issues/194
 - Use Gem winrm-fs 1.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Changelog
 
+### [1.6.0.1](https://github.com/stoned/rd-winrm-plugin/releases/tag/1.6.0.1)
+- Use Gem winrm 2.x which permit non-administrator session, see
+https://github.com/WinRb/WinRM/issues/194
+- Use Gem winrm-fs 1.x
+- Allow WinRM transport protocol to be specified (HTTP/HTTPS) so
+HTTPS can be selected without using 'ssl' authentication type.
+- Allow empty defaut user and password at the project level, or
+above, so only "overriding" in job options can be use instead
+- Mention in README the installation of Gem rubyntlm so NTLM
+authentification can be used, via authentication type 'negotiate'.
+
 ### [1.6.0](https://github.com/NetDocuments/rd-winrm-plugin/releases/tag/1.6.0)
 Enables basic auth (GH-34)
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Compatible with Rundeck 2.9.x+
 
 ## Features
 Can run scripts or commands.  
-Supports PowerShell, CMD and WQL shells  
-Can avoid quoting problems (should be removed after core Rundeck fixes)  
+Supports PowerShell, CMD and WQL shells    
 Can copy files to Windows  
 
 ### Installation
@@ -61,8 +60,7 @@ Settings:
 
 ### Limitations
 - Scripts in c:/tmp with .sh extension will be renamed into .ps1, .bat or .wql
-- Quotes behaviour can be strange (we trying to fix rundeck core strange behaviour, so our own also not perfect)
-- WQL execution never been tested :)
+- Quotes behaviour can be strange, [Rundeck bug](https://github.com/rundeck/rundeck/issues/602)
 
 ### Troubleshooting
 You may have some errors like ```WinRM::WinRMAuthorizationError```.  

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Download from the [releases page](https://github.com/NetDocuments/rd-winrm-plugi
 Copy the `rd-winrm-plugin.zip` to the `libext/` directory for Rundeck. It must be named like `rd-winrm-plugin-x.x.x.zip`. There is no need to restart rundeck.
 
 ```bash
-RD_WINRM='1.6.2'
+RD_WINRM='1.7.0'
 curl https://github.com/NetDocuments/rd-winrm-plugin/archive/$RD_WINRM.zip -o /var/lib/rundeck/libext/rd-winrm-plugin-$RD_WINRM.zip
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ CentOS/RHEL: `yum install make ruby ruby-devel`
 Install following gems:  
 `gem install winrm -v 2.2.3`  
 `gem install winrm-fs -v 1.0.2`  
+`gem install rubyntlm -v 0.6.2`  
 
 Download from the [releases page](https://github.com/NetDocuments/rd-winrm-plugin/releases).
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 ## Rd-WinRM-plugin
-This is a [Rundeck Node Execution plugin][1] that uses WinRM to connect to Windows and execute commands. It uses the [WinRM for Ruby][2] Library to provide the WinRM implementation
-[1]: http://rundeck.org/docs/plugins-user-guide/node-execution-plugins
-[2]: https://github.com/WinRb/WinRM
+This is a [Rundeck Node Execution plugin](http://rundeck.org/docs/plugins-user-guide/node-execution-plugins) that uses WinRM to connect to Windows and execute commands. It uses the [WinRM for Ruby](https://github.com/WinRb/WinRM)Library to provide the WinRM implementation.
 
-Compatible with Rundeck 2.3.x+
+Compatible with Rundeck 2.9.x+
 
 ## Features
-Can run scripts, not only commands  
-Can run PowerShell, CMD and WQL not only CMD  
+Can run scripts or commands.  
+Supports PowerShell, CMD and WQL shells  
 Can avoid quoting problems (should be removed after core Rundeck fixes)  
-Can copy files to windows  
+Can copy files to Windows  
 
 ### Installation
 
@@ -18,23 +16,21 @@ Ubuntu: `apt-get install make ruby ruby-dev`
 CentOS/RHEL: `yum install make ruby ruby-devel`
 
 Install following gems:  
-`gem install winrm -v 2.1.2`  
-`gem install winrm-fs -v 1.0.1`  
-`gem install rubyntlm`
+`gem install winrm -v 2.2.3`  
+`gem install winrm-fs -v 1.0.2`  
 
 Download from the [releases page](https://github.com/NetDocuments/rd-winrm-plugin/releases).
 
 Copy the `rd-winrm-plugin.zip` to the `libext/` directory for Rundeck. It must be named like `rd-winrm-plugin-x.x.x.zip`. There is no need to restart rundeck.
 
 ```bash
-RD_WINRM='1.5.1'
+RD_WINRM='1.6.2'
 curl https://github.com/NetDocuments/rd-winrm-plugin/archive/$RD_WINRM.zip -o /var/lib/rundeck/libext/rd-winrm-plugin-$RD_WINRM.zip
 ```
 
 Before rundeck can run commands on windows nodes, [configure winrm](https://technet.microsoft.com/en-us/magazine/ff700227.aspx) from an administrative powershell window
 
     winrm quickconfig
-
 
 ### Configuration
 Choose `WinRM Executor` as Default Node Executor  

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Ubuntu: `apt-get install make ruby ruby-dev`
 CentOS/RHEL: `yum install make ruby ruby-devel`
 
 Install following gems:  
-`gem install winrm -v 1.8.1`  
-`gem install winrm-fs -v 0.4.3`  
+`gem install winrm -v 2.1.2`  
+`gem install winrm-fs -v 1.0.1`  
+`gem install rubyntlm`
 
 Download from the [releases page](https://github.com/NetDocuments/rd-winrm-plugin/releases).
 
@@ -44,6 +45,7 @@ Settings:
 `Username` Put here username for negotiate, plaintext or ssl auth  
 `Password` Put here password for negotiate, plaintext or ssl auth  
 `Auth type` choose here negotiate, kerberos, plaintext or ssl  
+`WinRM transport protocol` set protocol for winrm transport (Default: http)
 `WinRM port` set port for winrm (Default: 5985/5986 for http/https)  
 `Shell` choose here powershell, cmd or wql  
 `WinRM timeout` put here time in seconds (useful for long running commands)  

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ Settings:
 `Kerberos Realm`  Put here fqdn of your realm in case your computer is part of AD domain  
 `Username` Put here username for negotiate, plaintext or ssl auth  
 `Password` Put here password for negotiate, plaintext or ssl auth  
-`Auth type` choose here negotiate, kerberos, plaintext or ssl  
-`WinRM transport protocol` set protocol for winrm transport (Default: http)
-`WinRM port` set port for winrm (Default: 5985/5986 for http/https)  
-`Shell` choose here powershell, cmd or wql  
-`WinRM timeout` put here time in seconds (useful for long running commands)  
+`Auth type` Choose here negotiate, kerberos, plaintext or ssl  
+`NOSSL` Choose to disable SSL Validation  
+`Allow override` Allow override of variables from job options  
+`WinRM transport protocol` Set protocol for winrm transport (Default: http)
+`WinRM port` Set port for winrm (Default: 5985/5986 for http/https)  
+`Shell` Choose here powershell, cmd or wql  
+`WinRM timeout` Put here timeout in seconds (useful for long running commands)  
 
 ![](http://cl.ly/1S1D2C070Z1T/Screenshot%202016-01-05%2016.51.53.png)
 

--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -2,6 +2,7 @@
 gem 'winrm-fs', '= 1.0.1'
 require 'winrm-fs'
 auth = ENV['RD_CONFIG_AUTHTYPE']
+nossl = ENV['RD_CONFIG_NOSSL'] == 'true' ? true : false
 if ENV['RD_CONFIG_USER'] # allow empy (default) password (override used)
   user = ENV['RD_CONFIG_USER'].dup # for some reason this string is frozen, so we duplicate it
 else
@@ -76,6 +77,7 @@ when 'ssl'
   connections_opts[:user] = user
   connections_opts[:password] = pass
   connections_opts[:disable_sspi] = true
+  connections_opts[:no_ssl_peer_verification] = nossl
 else
   fail "Invalid authtype '#{auth}' specified, expected: negotiate, kerberos, plaintext, ssl."
 end

--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -99,13 +99,37 @@ file_manager = WinRM::FS::FileManager.new(winrm)
 ## Upload file to host
 begin
   file_manager.upload(file, dest)
-rescue => e
+rescue HTTPClient::ConnectTimeoutError => e #Capture Timeout on FileCopy (Server Offline)
   if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
-    STDERR.print e.message + "\n"
-    STDERR.print e.backtrace.inspect
+    STDERR.print "FileCopy failed due to Timeout:\n"
+    STDERR.print "Exception Class: #{ e.class.name }\n"
+    STDERR.print "Exception Message: #{ e.message }\n"
+    STDERR.print "Exception Backtrace: #{ e.backtrace }\n"
     exit 1
   else
-    STDERR.print e.message
+    STDERR.print "FileCopy failed due to Timeout: #{ e.class.name }--#{ e.message }\n"
+    exit 1
+  end
+rescue WinRM::WinRMAuthorizationError => e #Capture WinRM Access error (Bad WinRM config)
+  if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
+    STDERR.print "FileCopy failed due to WinRM Access failure:\n"
+    STDERR.print "Exception Class: #{ e.class.name }\n"
+    STDERR.print "Exception Message: #{ e.message }\n"
+    STDERR.print "Exception Backtrace: #{ e.backtrace }\n"
+    exit 1
+  else
+    STDERR.print "FileCopy failed due to WinRM Access failure: #{ e.class.name }--#{ e.message }\n"
+    exit 1
+  end
+rescue => e
+  if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
+    STDERR.print "FileCopy failed due to unhandled exception\n"
+    STDERR.print "Exception Class: #{ e.class.name }\n"
+    STDERR.print "Exception Message: #{ e.message }\n"
+    STDERR.print "Exception Backtrace: #{ e.backtrace }\n"
+    exit 1
+  else
+    STDERR.print "FileCopy failed due to unhandled exception: #{ e.class.name }--#{ e.message }\n"
     exit 1
   end
 end

--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/ruby
-gem 'winrm-fs', '= 1.0.1'
+gem 'winrm-fs', '= 1.0.2'
 require 'winrm-fs'
 auth = ENV['RD_CONFIG_AUTHTYPE']
 nossl = ENV['RD_CONFIG_NOSSL'] == 'true' ? true : false

--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -1,11 +1,20 @@
 #!/usr/bin/ruby
-gem 'winrm-fs', '= 0.4.3'
+gem 'winrm-fs', '= 1.0.1'
 require 'winrm-fs'
 auth = ENV['RD_CONFIG_AUTHTYPE']
-user = ENV['RD_CONFIG_USER'].dup # for some reason these strings is frozen, so we duplicate it
-pass = ENV['RD_CONFIG_PASS'].dup
+if ENV['RD_CONFIG_USER'] # allow empy (default) password (override used)
+  user = ENV['RD_CONFIG_USER'].dup # for some reason this string is frozen, so we duplicate it
+else
+  user =''
+end
+if ENV['RD_CONFIG_PASS'] # allow empy (default) password (override used)
+  pass = ENV['RD_CONFIG_PASS'].dup # for some reason this string is frozen, so we duplicate it
+else
+  pass = ''
+end
 host = ENV['RD_NODE_HOSTNAME']
 port = ENV['RD_CONFIG_WINRMPORT']
+transport = ENV['RD_CONFIG_WINRMTRANSPORT']
 shell = ENV['RD_CONFIG_SHELL']
 realm = ENV['RD_CONFIG_KRB5_REALM']
 override = ENV['RD_CONFIG_ALLOWOVERRIDE']
@@ -18,7 +27,7 @@ dest = ARGV[2]
 if auth == 'ssl'
   endpoint = "https://#{host}:#{port}/wsman"
 else
-  endpoint = "http://#{host}:#{port}/wsman"
+  endpoint = "#{transport}://#{host}:#{port}/wsman"
 end
 
 # Wrapper to fix: "not setting executing flags by rundeck for 2nd file in plugin"
@@ -43,20 +52,35 @@ if %r{/tmp/.*\.sh}.match(dest)
   end
 end
 
+connections_opts = {
+  endpoint: endpoint
+}
+
+connections_opts[:operation_timeout] = ENV['RD_CONFIG_WINRMTIMEOUT'].to_i if ENV['RD_CONFIG_WINRMTIMEOUT']
+
 case auth
 when 'negotiate'
-  winrm = WinRM::WinRMWebService.new(endpoint, :negotiate, user: user, pass: pass)
+  connections_opts[:transport] = :negotiate
+  connections_opts[:user] = user
+  connections_opts[:password] = pass
 when 'kerberos'
-  winrm = WinRM::WinRMWebService.new(endpoint, :kerberos, realm: realm)
+  connections_opts[:transport] = :kerberos
+  connections_opts[:realm] = realm
 when 'plaintext'
-  winrm = WinRM::WinRMWebService.new(endpoint, :plaintext, user: user, pass: pass, disable_sspi: true)
+  connections_opts[:transport] = :plaintext
+  connections_opts[:user] = user
+  connections_opts[:password] = pass
+  connections_opts[:disable_sspi] = true
 when 'ssl'
-  winrm = WinRM::WinRMWebService.new(endpoint, :ssl, user: user, pass: pass, disable_sspi: true)
+  connections_opts[:transport] = :ssl
+  connections_opts[:user] = user
+  connections_opts[:password] = pass
+  connections_opts[:disable_sspi] = true
 else
-  fail "Invalid authtype '#{auth}' specified, expected: kerberos, plaintext, ssl."
+  fail "Invalid authtype '#{auth}' specified, expected: negotiate, kerberos, plaintext, ssl."
 end
 
-winrm.set_timeout(ENV['RD_CONFIG_WINRMTIMEOUT'].to_i) if ENV['RD_CONFIG_WINRMTIMEOUT']
+winrm = WinRM::Connection.new(connections_opts)
 
 file_manager = WinRM::FS::FileManager.new(winrm)
 

--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -86,5 +86,16 @@ winrm = WinRM::Connection.new(connections_opts)
 
 file_manager = WinRM::FS::FileManager.new(winrm)
 
-## Upload file to host
-file_manager.upload(file, dest)
+begin
+  ## Upload file to host
+  file_manager.upload(file, dest)
+rescue => e
+  if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
+    STDERR.print e.message + "\n"
+    STDERR.print e.backtrace.inspect
+    exit 1
+  else
+    STDERR.print e.message
+    exit 1
+  end
+end

--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -19,9 +19,14 @@ transport = ENV['RD_CONFIG_WINRMTRANSPORT']
 shell = ENV['RD_CONFIG_SHELL']
 realm = ENV['RD_CONFIG_KRB5_REALM']
 override = ENV['RD_CONFIG_ALLOWOVERRIDE']
+if ENV['RD_CONFIG_WINRMTIMEOUT']
+  timeout = ENV['RD_CONFIG_WINRMTIMEOUT'].to_i
+else
+  timeout = 60
+end
 host = ENV['RD_OPTION_WINRMHOST'] if ENV['RD_OPTION_WINRMHOST'] && (override == 'host' || override == 'all')
 user = ENV['RD_OPTION_WINRMUSER'].dup if ENV['RD_OPTION_WINRMUSER'] && (override == 'user' || override == 'all')
-pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'user' || override == 'all')
+pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'pass' || override == 'all')
 
 file = ARGV[1]
 dest = ARGV[2]
@@ -60,7 +65,7 @@ connections_opts = {
   endpoint: endpoint
 }
 
-connections_opts[:operation_timeout] = ENV['RD_CONFIG_WINRMTIMEOUT'].to_i if ENV['RD_CONFIG_WINRMTIMEOUT']
+connections_opts[:operation_timeout] = timeout
 
 case auth
 when 'negotiate'

--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -37,6 +37,7 @@ end
 if File.exist?("#{ENV['RD_PLUGIN_BASE']}/winrmexe.rb") && !File.executable?("#{ENV['RD_PLUGIN_BASE']}/winrmexe.rb")
   File.chmod(0764, "#{ENV['RD_PLUGIN_BASE']}/winrmexe.rb") # https://github.com/rundeck/rundeck/issues/1421
 end
+#---
 
 # Wrapper for avoid unix style file copying then scripts run
 # - not accept chmod call
@@ -52,7 +53,9 @@ if %r{/tmp/.*\.sh}.match(dest)
     dest = dest.gsub(/\.sh/, '.wql')
   end
 end
+#---
 
+# Build connection options
 connections_opts = {
   endpoint: endpoint
 }
@@ -81,13 +84,15 @@ when 'ssl'
 else
   fail "Invalid authtype '#{auth}' specified, expected: negotiate, kerberos, plaintext, ssl."
 end
+#---
 
+# Create session
 winrm = WinRM::Connection.new(connections_opts)
-
 file_manager = WinRM::FS::FileManager.new(winrm)
+#---
 
+## Upload file to host
 begin
-  ## Upload file to host
   file_manager.upload(file, dest)
 rescue => e
   if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
@@ -99,3 +104,4 @@ rescue => e
     exit 1
   end
 end
+#---

--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -86,11 +86,5 @@ winrm = WinRM::Connection.new(connections_opts)
 
 file_manager = WinRM::FS::FileManager.new(winrm)
 
-## upload file
+## Upload file to host
 file_manager.upload(file, dest)
-
-## upload the entire contents of my_dir to c:/foo/my_dir
-# file_manager.upload('/Users/sneal/my_dir', 'c:/foo/my_dir')
-
-## upload the entire directory contents of foo to c:\program files\bar
-# file_manager.upload('/Users/sneal/foo', '$env:ProgramFiles/bar')

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -20,9 +20,14 @@ shell = ENV['RD_CONFIG_SHELL']
 realm = ENV['RD_CONFIG_KRB5_REALM']
 command = ENV['RD_EXEC_COMMAND']
 override = ENV['RD_CONFIG_ALLOWOVERRIDE']
+if ENV['RD_CONFIG_WINRMTIMEOUT']
+  timeout = ENV['RD_CONFIG_WINRMTIMEOUT'].to_i
+else
+  timeout = 60
+end
 host = ENV['RD_OPTION_WINRMHOST'] if ENV['RD_OPTION_WINRMHOST'] && (override == 'host' || override == 'all')
 user = ENV['RD_OPTION_WINRMUSER'].dup if ENV['RD_OPTION_WINRMUSER'] && (override == 'user' || override == 'all')
-pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'user' || override == 'all')
+pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'pass' || override == 'all')
 
 if auth == 'ssl'
   endpoint = "https://#{host}:#{port}/wsman"
@@ -99,7 +104,7 @@ connections_opts = {
   endpoint: endpoint
 }
 
-connections_opts[:operation_timeout] = ENV['RD_CONFIG_WINRMTIMEOUT'].to_i if ENV['RD_CONFIG_WINRMTIMEOUT']
+connections_opts[:operation_timeout] = timeout
 
 case auth
 when 'negotiate'

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -1,11 +1,20 @@
 #!/usr/bin/ruby
-gem 'winrm', '= 1.8.1'
+gem 'winrm', '= 2.1.2'
 require 'winrm'
 auth = ENV['RD_CONFIG_AUTHTYPE']
-user = ENV['RD_CONFIG_USER'].dup # for some reason these strings is frozen, so we duplicate it
-pass = ENV['RD_CONFIG_PASS'].dup
+if ENV['RD_CONFIG_USER'] # allow empy (default) password (override used)
+  user = ENV['RD_CONFIG_USER'].dup # for some reason this string is frozen, so we duplicate it
+else
+  user =''
+end
+if ENV['RD_CONFIG_PASS'] # allow empy (default) password (override used)
+  pass = ENV['RD_CONFIG_PASS'].dup # for some reason this string is frozen, so we duplicate it
+else
+  pass = ''
+end
 host = ENV['RD_NODE_HOSTNAME']
 port = ENV['RD_CONFIG_WINRMPORT']
+transport = ENV['RD_CONFIG_WINRMTRANSPORT']
 shell = ENV['RD_CONFIG_SHELL']
 realm = ENV['RD_CONFIG_KRB5_REALM']
 command = ENV['RD_EXEC_COMMAND']
@@ -17,10 +26,8 @@ pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override
 if auth == 'ssl'
   endpoint = "https://#{host}:#{port}/wsman"
 else
-  endpoint = "http://#{host}:#{port}/wsman"
+  endpoint = "#{transport}://#{host}:#{port}/wsman"
 end
-ooutput = ''
-eoutput = ''
 
 # Wrapper to fix: "not setting executing flags by rundeck for 2nd file in plugin"
 # # https://github.com/rundeck/rundeck/issues/1421
@@ -91,55 +98,52 @@ def stderr_text(stderr)
   end
 end
 
+connections_opts = {
+  endpoint: endpoint
+}
+
+connections_opts[:operation_timeout] = ENV['RD_CONFIG_WINRMTIMEOUT'].to_i if ENV['RD_CONFIG_WINRMTIMEOUT']
+
 case auth
 when 'negotiate'
-  winrm = WinRM::WinRMWebService.new(endpoint, :negotiate, user: user, pass: pass)
+  connections_opts[:transport] = :negotiate
+  connections_opts[:user] = user
+  connections_opts[:password] = pass
 when 'kerberos'
-  winrm = WinRM::WinRMWebService.new(endpoint, :kerberos, realm: realm)
+  connections_opts[:transport] = :kerberos
+  connections_opts[:realm] = realm
 when 'plaintext'
-  winrm = WinRM::WinRMWebService.new(endpoint, :plaintext, user: user, pass: pass, disable_sspi: true)
+  connections_opts[:transport] = :plaintext
+  connections_opts[:user] = user
+  connections_opts[:password] = pass
+  connections_opts[:disable_sspi] = true
 when 'ssl'
-  winrm = WinRM::WinRMWebService.new(endpoint, :ssl, user: user, pass: pass, disable_sspi: true)
+  connections_opts[:transport] = :ssl
+  connections_opts[:user] = user
+  connections_opts[:password] = pass
+  connections_opts[:disable_sspi] = true
 else
-  fail "Invalid authtype '#{auth}' specified, expected: kerberos, plaintext, ssl."
+  fail "Invalid authtype '#{auth}' specified, expected: negotiate, kerberos, plaintext, ssl."
 end
 
-winrm.set_timeout(ENV['RD_CONFIG_WINRMTIMEOUT'].to_i) if ENV['RD_CONFIG_WINRMTIMEOUT']
+winrm = WinRM::Connection.new(connections_opts)
 
+shell_session = nil
 case shell
 when 'powershell'
-  result = winrm.create_executor().run_powershell_script(command)
+  shell_session = winrm.shell(:powershell)
+  result = shell_session.run(command)
 when 'cmd'
-  result = winrm.create_executor().run_cmd(command)
+  shell_session = winrm.shell(:cmd)
+  result = shell_session.run(command)
 when 'wql'
-  result = winrm.wql(command)
+  result = winrm.run_wql(command)
 end
 
-result[:data].each do |output_line|
-  eoutput = "#{eoutput}#{output_line[:stderr]}" if output_line.key?(:stderr)
-  ooutput = "#{ooutput}#{output_line[:stdout]}" if output_line.key?(:stdout)
+if shell_session != nil
+  STDERR.print stderr_text(result.stderr) if result.stderr != ''
+  STDOUT.print result.stdout
+  exit result.exitcode if result.exitcode !=0
+else # WQL
+  STDOUT.print result
 end
-
-STDERR.print stderr_text(eoutput) if eoutput != ''
-STDOUT.print ooutput
-exit result[:exitcode] if result[:exitcode] != 0
-
-# winrm.powershell(command) do |stdout, stderr|
-#   STDOUT.print stdout
-#   STDERR.print stderr
-# end
-
-# result = winrm.cmd(command)
-# if result[:exitcode] != 0
-#    result[:data].each do |output_line|
-#          if output_line.has_key?(:stderr)
-#                  STDOUT.print output_line[:stderr]
-#                      end
-#            end
-# else
-#    result[:data].each do |output_line|
-#          if output_line.has_key?(:stdout)
-#                  STDOUT.print output_line[:stdout]
-#                      end
-#            end
-# end

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -2,6 +2,7 @@
 gem 'winrm', '= 2.1.2'
 require 'winrm'
 auth = ENV['RD_CONFIG_AUTHTYPE']
+nossl = ENV['RD_CONFIG_NOSSL'] == 'true' ? true : false
 if ENV['RD_CONFIG_USER'] # allow empy (default) password (override used)
   user = ENV['RD_CONFIG_USER'].dup # for some reason this string is frozen, so we duplicate it
 else
@@ -36,7 +37,7 @@ if File.exist?("#{ENV['RD_PLUGIN_BASE']}/winrmcp.rb") && !File.executable?("#{EN
   File.chmod(0764, "#{ENV['RD_PLUGIN_BASE']}/winrmcp.rb")
 end
 
-# Wrapper ro avoid strange and undocumented behavior of rundeck
+# Wrapper to avoid strange and undocumented behavior of rundeck
 # Should be deleted after rundeck fix
 # https://github.com/rundeck/rundeck/issues/602
 command = command.gsub(/'"'"'' /, '\'')
@@ -122,6 +123,7 @@ when 'ssl'
   connections_opts[:user] = user
   connections_opts[:password] = pass
   connections_opts[:disable_sspi] = true
+  connections_opts[:no_ssl_peer_verification] = nossl
 else
   fail "Invalid authtype '#{auth}' specified, expected: negotiate, kerberos, plaintext, ssl."
 end

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -164,7 +164,7 @@ when 'wql'
 end
 #---
 
-# Organise output for return to Runeck
+# Organise output for return to Rundeck
 if shell_session != nil
   STDERR.print stderr_text(result.stderr) if result.stderr != ''
   STDOUT.print result.stdout

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -38,15 +38,6 @@ if File.exist?("#{ENV['RD_PLUGIN_BASE']}/winrmcp.rb") && !File.executable?("#{EN
 end
 #---
 
-# Wrapper to avoid strange and undocumented behavior of rundeck
-# Should be deleted after rundeck fix
-# https://github.com/rundeck/rundeck/issues/602
-command = command.gsub(/'"'"'' /, '\'')
-command = command.gsub(/ ''"'"'/, '\'')
-command = command.gsub(/ '"/, '"')
-command = command.gsub(/"' /, '"')
-#---
-
 # Wrapper for avoid unix style file copying then scripts run
 # - not accept chmod call
 # - replace rm -f into rm -force

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/ruby
-gem 'winrm', '= 2.1.2'
+gem 'winrm', '= 2.2.3'
 require 'winrm'
 auth = ENV['RD_CONFIG_AUTHTYPE']
 nossl = ENV['RD_CONFIG_NOSSL'] == 'true' ? true : false

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -73,6 +73,7 @@ if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
   puts "endpoint => #{endpoint}"
   puts "user => #{user}"
   puts 'pass => ********'
+  puts "timeout => #{timeout}"
   # puts "pass => #{pass}" # uncomment it for full auth debugging
   puts "command => #{ENV['RD_EXEC_COMMAND']}"
   puts "newcommand => #{command}"
@@ -141,11 +142,13 @@ when 'powershell'
   rescue => e
     shell_session = nil
     if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
-      STDERR.print "Connection Failure: " + e.message + "\n"
-      STDERR.print e.backtrace.inspect
+      STDERR.print "ScriptExecution failed due unhandled exception:\n"
+      STDERR.print "Exception Class: #{ e.class.name }\n"
+      STDERR.print "Exception Message: #{ e.message }\n"
+      STDERR.print "Exception Backtrace: #{ e.backtrace }\n"
       exit 1
     else
-      STDERR.print "Connection Failure: " + e.message + "\n"
+      STDERR.print "ScriptExecution failed due unhandled exception: #{ e.class.name }--#{ e.message }\n"
       exit 1
     end
   end
@@ -156,12 +159,14 @@ when 'cmd'
   rescue => e
     shell_session = nil
     if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
-      STDERR.print "Connection Failure: " + e.message + "\n"
-      STDERR.print e.backtrace.inspect
-      exit 2
+      STDERR.print "ScriptExecution failed due unhandled exception:\n"
+      STDERR.print "Exception Class: #{ e.class.name }\n"
+      STDERR.print "Exception Message: #{ e.message }\n"
+      STDERR.print "Exception Backtrace: #{ e.backtrace }\n"
+      exit 1
     else
-      STDERR.print "Connection Failure: " + e.message + "\n"
-      exit 2
+      STDERR.print "ScriptExecution failed due unhandled exception: #{ e.class.name }--#{ e.message }\n"
+      exit 1
     end
   end
 when 'wql'

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -36,6 +36,7 @@ end
 if File.exist?("#{ENV['RD_PLUGIN_BASE']}/winrmcp.rb") && !File.executable?("#{ENV['RD_PLUGIN_BASE']}/winrmcp.rb")
   File.chmod(0764, "#{ENV['RD_PLUGIN_BASE']}/winrmcp.rb")
 end
+#---
 
 # Wrapper to avoid strange and undocumented behavior of rundeck
 # Should be deleted after rundeck fix
@@ -44,6 +45,7 @@ command = command.gsub(/'"'"'' /, '\'')
 command = command.gsub(/ ''"'"'/, '\'')
 command = command.gsub(/ '"/, '"')
 command = command.gsub(/"' /, '"')
+#---
 
 # Wrapper for avoid unix style file copying then scripts run
 # - not accept chmod call
@@ -66,7 +68,9 @@ if %r{/tmp/.*\.sh}.match(command)
     command = command.gsub(/\.sh/, '.wql')
   end
 end
+#---
 
+# Output DEBUG messages
 if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
   puts 'variables:'
   puts "realm => #{realm}"
@@ -99,6 +103,7 @@ def stderr_text(stderr)
   end
 end
 
+# Build connection options
 connections_opts = {
   endpoint: endpoint
 }
@@ -127,9 +132,10 @@ when 'ssl'
 else
   fail "Invalid authtype '#{auth}' specified, expected: negotiate, kerberos, plaintext, ssl."
 end
+#---
 
+# Create and connect session
 winrm = WinRM::Connection.new(connections_opts)
-
 shell_session = nil
 case shell
 when 'powershell'
@@ -137,26 +143,42 @@ when 'powershell'
     shell_session = winrm.shell(:powershell)
     result = shell_session.run(command)
   rescue => e
+    shell_session = nil
     if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
-      STDERR.print e.message + "\n"
+      STDERR.print "Connection Failure: " + e.message + "\n"
       STDERR.print e.backtrace.inspect
       exit 1
     else
-      STDERR.print e.message
+      STDERR.print "Connection Failure: " + e.message + "\n"
       exit 1
     end
   end
 when 'cmd'
-  shell_session = winrm.shell(:cmd)
-  result = shell_session.run(command)
+  begin
+    shell_session = winrm.shell(:cmd)
+    result = shell_session.run(command)
+  rescue => e
+    shell_session = nil
+    if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
+      STDERR.print "Connection Failure: " + e.message + "\n"
+      STDERR.print e.backtrace.inspect
+      exit 2
+    else
+      STDERR.print "Connection Failure: " + e.message + "\n"
+      exit 2
+    end
+  end
 when 'wql'
   result = winrm.run_wql(command)
 end
+#---
 
-if result != nil
+# Organise output for return to Runeck
+if shell_session != nil
   STDERR.print stderr_text(result.stderr) if result.stderr != ''
   STDOUT.print result.stdout
   exit result.exitcode if result.exitcode !=0
 else # WQL
   STDOUT.print result
 end
+#---

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: rd-winrm-plugin
 version: 1.6.2
-rundeckPluginVersion: 1.0
+rundeckPluginVersion: 1.2
 author: Volodymyr Babchynskyy
 date: 26.10.2015
 providers:
@@ -11,8 +11,8 @@ providers:
     plugin-type: script
     script-interpreter: ruby
     script-file: winrmexe.rb
-#    script-args: ${config.realm} ${config.username} ${config.password} ${node.hostname} ${exec.command}
-    interpreter-args-quoted: true
+    # script-args: ${config.realm} ${config.username} ${config.password} ${node.hostname} ${exec.command}
+    # interpreter-args-quoted: true
     config:
       - name: krb5_realm
         title: Kerberos Realm

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: rd-winrm-plugin
-version: 1.7.1
+version: 1.7.0
 rundeckPluginVersion: 1.2
 author: Volodymyr Babchynskyy
 date: 26.10.2015

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: rd-winrm-plugin
-version: 1.5.1
+version: 1.6.0.2  
 rundeckPluginVersion: 1.0
 author: Volodymyr Babchynskyy
 date: 26.10.2015
@@ -21,7 +21,7 @@ providers:
         description: "Kerberos Realm FQDN in capital letters"
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "krb5_realm"
+          instance-scope-node-attribute: "rd-winrm-krb5_realm"
       - name: user
         title: Username
         description: "Username in DOMAIN\\name form"
@@ -29,7 +29,7 @@ providers:
         required: false
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "user"
+          instance-scope-node-attribute: "rd-winrm-user"
       - name: pass
         title: Password
         description: "Password"
@@ -38,6 +38,7 @@ providers:
         scope: Instance
         renderingOptions:
           displayType: PASSWORD
+          instance-scope-node-attribute: "rd-winrm-password"
       - name: authtype
         title: Auth type
         description: "Authentication type"
@@ -47,7 +48,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "authtype"
+          instance-scope-node-attribute: "rd-winrm-authtype"
       - name: allowoverride
         title: Allow Override
         description: "Gives possibility to override hostname, username (and password) in job options"
@@ -57,7 +58,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "allowoverride"
+          instance-scope-node-attribute: "rd-winrm-allowoverride"
       - name: winrmtransport
         title: WinRM transport protocol
         description: "WinRM transport protocol (Default: http or https when ssl is selected for Authentication type)"
@@ -67,7 +68,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "winrmtransport"
+          instance-scope-node-attribute: "rd-winrm-transport"
       - name: winrmport
         title: WinRM port
         description: "WinRM port (Default: 5985/5986 for http/https)"
@@ -76,7 +77,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "winrmport"
+          instance-scope-node-attribute: "rd-winrm-port"
       - name: shell
         title: Shell
         description: "Windows interpreter"
@@ -86,7 +87,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "shell"
+          instance-scope-node-attribute: "rd-winrm-shell"
       - name: winrmtimeout
         title: WinRM timeout
         description: "timeout in seconds default: 60"
@@ -94,7 +95,7 @@ providers:
         required: false
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "winrmtimeout"
+          instance-scope-node-attribute: "rd-winrm-timeout"
   - name: WinRMcp
     title: WinRM File Copier
     service: FileCopier
@@ -110,7 +111,7 @@ providers:
         description: "Kerberos Realm FQDN in capital letters"
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "krb5_realm"
+          instance-scope-node-attribute: "rd-winrm-krb5_realm"
       - name: user
         title: Username
         type: String
@@ -118,7 +119,7 @@ providers:
         description: "Username in DOMAIN\\name form"
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "user"
+          instance-scope-node-attribute: "rd-winrm-user"
       - name: pass
         title: Password
         type: String
@@ -127,6 +128,7 @@ providers:
         scope: Instance
         renderingOptions:
           displayType: PASSWORD
+          instance-scope-node-attribute: "rd-winrm-password"
       - name: authtype
         title: Auth type
         description: "Authentication type"
@@ -136,7 +138,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "authtype"
+          instance-scope-node-attribute: "rd-winrm-authtype"
       - name: allowoverride
         title: Allow Override
         description: "Gives possibility to override hostname, username (and password) in job options"
@@ -146,7 +148,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "allowoverride"
+          instance-scope-node-attribute: "rd-winrm-allowoverride"
       - name: winrmtransport
         title: WinRM transport protocol
         description: "WinRM transport protocol (Default: http or https when ssl is selected for Authentication type)"
@@ -156,7 +158,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "winrmtransport"
+          instance-scope-node-attribute: "rd-winrm-transport"
       - name: winrmport
         title: WinRM port
         description: "WinRM port (Default: 5985/5986 for http/https)"
@@ -165,7 +167,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "winrmport"
+          instance-scope-node-attribute: "rd-winrm-port"
       - name: shell
         title: Shell
         description: "Windows interpreter. Should be same as in Executor"
@@ -175,7 +177,7 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "shell"
+          instance-scope-node-attribute: "rd-winrm-shell"
       - name: winrmtimeout
         title: WinRM timeout
         description: "timeout in seconds default: 60"
@@ -183,4 +185,4 @@ providers:
         required: false
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "winrmtimeout"
+          instance-scope-node-attribute: "rd-winrm-winrmtimeout"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,7 +6,7 @@ date: 26.10.2015
 providers:
   - name: WinRMexe
     title: WinRM Executor
-    description: Executing Scripts or commands on remote windows computer
+    description: Executing Scripts or Commands on remote Windows computer
     service: NodeExecutor
     plugin-type: script
     script-interpreter: ruby
@@ -24,7 +24,7 @@ providers:
           instance-scope-node-attribute: "rd-winrm-krb5_realm"
       - name: user
         title: Username
-        description: "Username in DOMAIN\\name form"
+        description: "Username in DOMAIN\\name format"
         type: String
         required: false
         scope: Instance
@@ -40,7 +40,7 @@ providers:
           displayType: PASSWORD
           instance-scope-node-attribute: "rd-winrm-password"
       - name: authtype
-        title: Auth type
+        title: Authentication type
         description: "Authentication type"
         type: Select
         values: "negotiate, ssl, kerberos, plaintext"
@@ -100,7 +100,7 @@ providers:
           instance-scope-node-attribute: "rd-winrm-shell"
       - name: winrmtimeout
         title: WinRM timeout
-        description: "timeout in seconds default: 60"
+        description: "Timeout in seconds default: 60"
         type: Integer
         required: false
         scope: Instance
@@ -108,6 +108,7 @@ providers:
           instance-scope-node-attribute: "rd-winrm-timeout"
   - name: WinRMcp
     title: WinRM File Copier
+    description: Copying files to remote Windows computer
     service: FileCopier
     plugin-type: script
     script-interpreter: ruby
@@ -124,23 +125,23 @@ providers:
           instance-scope-node-attribute: "rd-winrm-krb5_realm"
       - name: user
         title: Username
+        description: "Username in DOMAIN\\name format"
         type: String
         required: false
-        description: "Username in DOMAIN\\name form"
         scope: Instance
         renderingOptions:
           instance-scope-node-attribute: "rd-winrm-user"
       - name: pass
         title: Password
+        description: "Password"
         type: String
         required: false
-        description: "Password"
         scope: Instance
         renderingOptions:
           displayType: PASSWORD
           instance-scope-node-attribute: "rd-winrm-password"
       - name: authtype
-        title: Auth type
+        title: Authentication type
         description: "Authentication type"
         type: Select
         values: "negotiate, ssl, kerberos, plaintext"
@@ -190,7 +191,7 @@ providers:
           instance-scope-node-attribute: "rd-winrm-port"
       - name: shell
         title: Shell
-        description: "Windows interpreter. Should be same as in Executor"
+        description: "Windows interpreter. Should match setting in Executor"
         type: Select
         values: "cmd, powershell, wql"
         default: 'powershell'
@@ -200,9 +201,9 @@ providers:
           instance-scope-node-attribute: "rd-winrm-shell"
       - name: winrmtimeout
         title: WinRM timeout
-        description: "timeout in seconds default: 60"
+        description: "Timeout in seconds default: 60"
         type: Integer
         required: false
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "rd-winrm-winrmtimeout"
+          instance-scope-node-attribute: "rd-winrm-timeout"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: rd-winrm-plugin
-version: 1.6.0.2
+version: 1.6.2
 rundeckPluginVersion: 1.0
 author: Volodymyr Babchynskyy
 date: 26.10.2015

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: rd-winrm-plugin
-version: 1.6.0.2  
+version: 1.6.0.2
 rundeckPluginVersion: 1.0
 author: Volodymyr Babchynskyy
 date: 26.10.2015
@@ -49,6 +49,16 @@ providers:
         scope: Instance
         renderingOptions:
           instance-scope-node-attribute: "rd-winrm-authtype"
+      - name: nossl
+        title: No SSL verification
+        description: "When set to true ssl certificate validation is not performed "
+        type: Select
+        values: "true, false"
+        default: "false"
+        required: true
+        scope: Instance
+        renderingOptions:
+          instance-scope-node-attribute: "rd-winrm-nossl"
       - name: allowoverride
         title: Allow Override
         description: "Gives possibility to override hostname, username (and password) in job options"
@@ -139,6 +149,16 @@ providers:
         scope: Instance
         renderingOptions:
           instance-scope-node-attribute: "rd-winrm-authtype"
+      - name: nossl
+        title: No SSL verification
+        description: "When set to true ssl certificate validation is not performed "
+        type: Select
+        values: "true, false"
+        default: "false"
+        required: true
+        scope: Instance
+        renderingOptions:
+          instance-scope-node-attribute: "rd-winrm-nossl"
       - name: allowoverride
         title: Allow Override
         description: "Gives possibility to override hostname, username (and password) in job options"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: rd-winrm-plugin
-version: 1.6.2
+version: 1.7.0
 rundeckPluginVersion: 1.2
 author: Volodymyr Babchynskyy
 date: 26.10.2015
@@ -11,8 +11,6 @@ providers:
     plugin-type: script
     script-interpreter: ruby
     script-file: winrmexe.rb
-    # script-args: ${config.realm} ${config.username} ${config.password} ${node.hostname} ${exec.command}
-    # interpreter-args-quoted: true
     config:
       - name: krb5_realm
         title: Kerberos Realm

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -58,6 +58,16 @@ providers:
         scope: Instance
         renderingOptions:
           instance-scope-node-attribute: "allowoverride"
+      - name: winrmtransport
+        title: WinRM transport protocol
+        description: "WinRM transport protocol (Default: http or https when ssl is selected for Authentication type)"
+        type: Select
+        default: "http"
+        values: "http, https"
+        required: true
+        scope: Instance
+        renderingOptions:
+          instance-scope-node-attribute: "winrmtransport"
       - name: winrmport
         title: WinRM port
         description: "WinRM port (Default: 5985/5986 for http/https)"
@@ -137,6 +147,16 @@ providers:
         scope: Instance
         renderingOptions:
           instance-scope-node-attribute: "allowoverride"
+      - name: winrmtransport
+        title: WinRM transport protocol
+        description: "WinRM transport protocol (Default: http or https when ssl is selected for Authentication type)"
+        type: Select
+        default: "http"
+        values: "http, https"
+        required: true
+        scope: Instance
+        renderingOptions:
+          instance-scope-node-attribute: "winrmtransport"
       - name: winrmport
         title: WinRM port
         description: "WinRM port (Default: 5985/5986 for http/https)"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: rd-winrm-plugin
-version: 1.7.0
+version: 1.7.1
 rundeckPluginVersion: 1.2
 author: Volodymyr Babchynskyy
 date: 26.10.2015
@@ -19,6 +19,7 @@ providers:
         description: "Kerberos Realm FQDN in capital letters"
         scope: Instance
         renderingOptions:
+          groupName: Authentication
           instance-scope-node-attribute: "rd-winrm-krb5_realm"
       - name: user
         title: Username
@@ -27,6 +28,7 @@ providers:
         required: false
         scope: Instance
         renderingOptions:
+          groupName: Authentication
           instance-scope-node-attribute: "rd-winrm-user"
       - name: pass
         title: Password
@@ -36,26 +38,29 @@ providers:
         scope: Instance
         renderingOptions:
           displayType: PASSWORD
+          groupName: Authentication
           instance-scope-node-attribute: "rd-winrm-password"
       - name: authtype
-        title: Authentication type
-        description: "Authentication type"
+        title: Authentication Type
+        description: "Authentication Type"
         type: Select
         values: "negotiate, ssl, kerberos, plaintext"
         default: "plaintext"
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Authentication
           instance-scope-node-attribute: "rd-winrm-authtype"
       - name: nossl
-        title: No SSL verification
-        description: "When set to true ssl certificate validation is not performed "
+        title: No SSL Verification
+        description: "When set to true ssl certificate validation is not performed"
         type: Select
         values: "true, false"
         default: "false"
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-nossl"
       - name: allowoverride
         title: Allow Override
@@ -66,9 +71,10 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-allowoverride"
       - name: winrmtransport
-        title: WinRM transport protocol
+        title: WinRM Transport Protocol
         description: "WinRM transport protocol (Default: http or https when ssl is selected for Authentication type)"
         type: Select
         default: "http"
@@ -76,33 +82,37 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-transport"
       - name: winrmport
-        title: WinRM port
+        title: WinRM Port
         description: "WinRM port (Default: 5985/5986 for http/https)"
         type: String
         default: "5985"
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-port"
       - name: shell
         title: Shell
-        description: "Windows interpreter"
+        description: "Windows Shell interpreter"
         type: Select
         values: "cmd, powershell, wql"
         default: 'powershell'
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-shell"
       - name: winrmtimeout
-        title: WinRM timeout
+        title: WinRM Timeout
         description: "Timeout in seconds default: 60"
         type: Integer
         required: false
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-timeout"
   - name: WinRMcp
     title: WinRM File Copier
@@ -120,6 +130,7 @@ providers:
         description: "Kerberos Realm FQDN in capital letters"
         scope: Instance
         renderingOptions:
+          groupName: Authentication
           instance-scope-node-attribute: "rd-winrm-krb5_realm"
       - name: user
         title: Username
@@ -128,6 +139,7 @@ providers:
         required: false
         scope: Instance
         renderingOptions:
+          groupName: Authentication
           instance-scope-node-attribute: "rd-winrm-user"
       - name: pass
         title: Password
@@ -137,26 +149,29 @@ providers:
         scope: Instance
         renderingOptions:
           displayType: PASSWORD
+          groupName: Authentication
           instance-scope-node-attribute: "rd-winrm-password"
       - name: authtype
-        title: Authentication type
-        description: "Authentication type"
+        title: Authentication Type
+        description: "Authentication Type"
         type: Select
         values: "negotiate, ssl, kerberos, plaintext"
         default: "plaintext"
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Authentication
           instance-scope-node-attribute: "rd-winrm-authtype"
       - name: nossl
-        title: No SSL verification
-        description: "When set to true ssl certificate validation is not performed "
+        title: No SSL Verification
+        description: "When set to true ssl certificate validation is not performed"
         type: Select
         values: "true, false"
         default: "false"
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-nossl"
       - name: allowoverride
         title: Allow Override
@@ -167,9 +182,10 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-allowoverride"
       - name: winrmtransport
-        title: WinRM transport protocol
+        title: WinRM Transport Protocol
         description: "WinRM transport protocol (Default: http or https when ssl is selected for Authentication type)"
         type: Select
         default: "http"
@@ -177,31 +193,35 @@ providers:
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-transport"
       - name: winrmport
-        title: WinRM port
+        title: WinRM Port
         description: "WinRM port (Default: 5985/5986 for http/https)"
         type: String
         default: "5985"
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-port"
       - name: shell
         title: Shell
-        description: "Windows interpreter. Should match setting in Executor"
+        description: "Windows Shell interpreter"
         type: Select
         values: "cmd, powershell, wql"
         default: 'powershell'
         required: true
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-shell"
       - name: winrmtimeout
-        title: WinRM timeout
+        title: WinRM Timeout
         description: "Timeout in seconds default: 60"
         type: Integer
         required: false
         scope: Instance
         renderingOptions:
+          groupName: Connection
           instance-scope-node-attribute: "rd-winrm-timeout"


### PR DESCRIPTION
Hi guys,

I pulled in the changes Stoned and Rodolfo made in my personal branch, then built on top of those some improvements I've been wanting around the error handling.

You'll now only get the full Ruby stack trace if the job is ran in DEBUG mode.
Otherwise you'll get a simple message in NORMAL mode, this makes the plugin much friendlier for non dev's reading the job outputs and for parsing in other systems.

Any other requests/recommendations?
I'm using this updated code on both my Test and Production systems at the moment with no issue.