### PR TITLE
override == 'pass' doesn't exist, valid values are : none, host, user, all

### DIFF
--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -26,7 +26,7 @@ else
 end
 host = ENV['RD_OPTION_WINRMHOST'] if ENV['RD_OPTION_WINRMHOST'] && (override == 'host' || override == 'all')
 user = ENV['RD_OPTION_WINRMUSER'].dup if ENV['RD_OPTION_WINRMUSER'] && (override == 'user' || override == 'all')
-pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'pass' || override == 'all')
+pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'user' || override == 'all')
 
 file = ARGV[1]
 dest = ARGV[2]

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -27,7 +27,7 @@ else
 end
 host = ENV['RD_OPTION_WINRMHOST'] if ENV['RD_OPTION_WINRMHOST'] && (override == 'host' || override == 'all')
 user = ENV['RD_OPTION_WINRMUSER'].dup if ENV['RD_OPTION_WINRMUSER'] && (override == 'user' || override == 'all')
-pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'pass' || override == 'all')
+pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'user' || override == 'all')
 
 if auth == 'ssl'
   endpoint = "https://#{host}:#{port}/wsman"


### PR DESCRIPTION
WinRM raise an error when authenticating : WinRM::WinRMAuthorizationError
This is due to the 'pass' empty variable if we set 'Allow Override' to user